### PR TITLE
Allow urls in the steps to be empty and not throw an error

### DIFF
--- a/components/Step/index.js
+++ b/components/Step/index.js
@@ -93,26 +93,46 @@ export class Step extends UnmountAwareComponent {
     });
     const borderRadius = getBorderRadiusForViewport(mobileViewport);
 
-    return (
-      <AnimatedContainer
-        onLayout={this.handleLayout}
-        style={{ backgroundColor, borderRadius }}
-      >
-        <Left>
-          <Name>{name}</Name>
-          <Urls>
-            {urls.map(url => (
-              <Url key={url}>
-                <Link href={url} disabled={!linksEnabled} />
-              </Url>
-            ))}
-          </Urls>
-        </Left>
-        <ButtonContainer>
-          <Checkbox checked={state === 'checked'} />
-        </ButtonContainer>
-      </AnimatedContainer>
-    );
+    if (typeof urls !== 'undefined' && urls.length > 0) {
+      return (
+        <AnimatedContainer
+          onLayout={this.handleLayout}
+          style={{ backgroundColor, borderRadius }}
+        >
+          <Left>
+            <Name>{name}</Name>
+            <Urls>
+              {urls.map(url => (
+                <Url key={url}>
+                  <Link href={url} disabled={!linksEnabled} />
+                </Url>
+              ))}
+            </Urls>
+          </Left>
+          <ButtonContainer>
+            <Checkbox checked={state === 'checked'} />
+          </ButtonContainer>
+        </AnimatedContainer>
+      );
+    }
+    else {
+      return (
+        <AnimatedContainer
+          onLayout={this.handleLayout}
+          style={{ backgroundColor, borderRadius }}
+        >
+          <Left>
+            <Name>{name}</Name>
+            <Urls>
+            </Urls>
+          </Left>
+          <ButtonContainer>
+            <Checkbox checked={state === 'checked'} />
+          </ButtonContainer>
+        </AnimatedContainer>
+      );
+    }
+    
   }
 }
 

--- a/components/shared/propTypes.js
+++ b/components/shared/propTypes.js
@@ -4,7 +4,7 @@ export const stepStateType = oneOf(['disabled', 'active', 'checked']);
 
 export const stepType = shape({
   name: string.isRequired,
-  urls: arrayOf(string).isRequired
+  urls: arrayOf(string)
 });
 
 export const activitiesType = objectOf(arrayOf(string));


### PR DESCRIPTION
I noticed that when creating steps in ```data.js``` having atleast one url for each step was required, if you didn't provide a url the app would crash.

I'm fairly new to all of this but I trial-ed and error-ed it, along with some good ol' Google and think I have a fix. I tested locally on my Windows 10 machine and seems to work well for when:

- Each step has one or more url
- Some steps have one or more urls and others have no urls
- No steps have urls

Let me know your thoughts!