### PR TITLE
Fix Add to Homescreen on Firefox on Android

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -16,5 +16,6 @@
   ],
   "theme_color": "#000915",
   "background_color": "#eaedf7",
-  "display": "standalone"
+  "display": "standalone",
+  "start_url": "/"
 }


### PR DESCRIPTION
This change fixes Add to Homescreen functionality for Android Firefox users by adding the `start_url` field to the webmanifest.

Relevant docs:  [MDN](https://developer.mozilla.org/en-US/docs/Web/Apps/Progressive/Add_to_home_screen#How_do_you_make_an_app_A2HS-ready)

Before, homescreen shortcut launches page with browser chrome:
![before](https://user-images.githubusercontent.com/502747/50976096-08d9c080-14e7-11e9-92fe-58f9772199f5.jpg)

After, homescreen shortcut launches page without browser chrome:
![after](https://user-images.githubusercontent.com/502747/50976149-2a3aac80-14e7-11e9-95f4-34dd9feea183.jpg)